### PR TITLE
LDLt support, accelerating bissect, completing example

### DIFF
--- a/src/front.jl
+++ b/src/front.jl
@@ -138,16 +138,13 @@ function Cholesky!{F}(front::Front{F})
 end
 
 
-
-
-# From http://www.mathworks.com/matlabcentral/fileexchange/47-ldlt/content/ldlt/ldlt.m, under BSD license
-# http://www.mathworks.com/matlabcentral/fileexchange/view_license?file_info_id=47
-# Updathe the lower-triangular part of A with, on the diagonal, d, and lower, L, such that
+# Updates the lower-triangular part of A with, on the diagonal, d, and lower, L, such that
 # A = LDL' 
 # where L is unit-lower-triangular
 #       D is diagonal
 # This function does not care about the strict-upper part of A
 function ldlt!(A)
+# From Golub & Van Loan, 4th edition, page 158
     n = size(A,1)
     size(A,2) == n || error("A should be square")
     v = zeros(Float64,n,1)
@@ -182,4 +179,3 @@ function gsyrk!(A,B,D)
         end
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,5 @@
 using MultiFrontalCholesky, Graphs
 
-function sparseToAdj(M)
-    if M.m != M.n
-        error("Expected a symmetric matrix")
-    end
-    n = M.n
-    g = simple_adjlist(n,is_directed=false)
-    for j=1:n
-        for k=M.colptr[j]:M.colptr[j+1]-1
-            i = M.rowval[k]
-            if i > j
-                add_edge!(g,i,j)
-            end
-        end
-    end
-    g
-end
-
 function appendel(I,J,V,i,j,v)
     push!(I,i)
     push!(J,j)
@@ -46,7 +29,7 @@ leafSize = 64;
 
 A = laplacian2d(nx,ny)
 
-g = sparseToAdj(A);
+g = simple_adjlist(A);
 b = randn(nx*ny,1) ;
 p = collect(1:size(A,1))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,34 +1,73 @@
-using MultiFrontalCholesky,Compat,Graphs
-using Base.Test
+using MultiFrontalCholesky, Graphs
 
-function appendel(I,J,V,i,j,v)
-    push!(I,i)
-    push!(J,j)
-    push!(V,v)
+function sparseToAdj(M)
+    if M.m != M.n
+        error("Expected a symmetric matrix")
+    end
+    n = M.n
+    g = simple_adjlist(n,is_directed=false)
+    for j=1:n
+        for k=M.colptr[j]:M.colptr[j+1]-1
+            i = M.rowval[k]
+            if i > j
+                add_edge!(g,i,j)
+            end
+        end
+    end
+    g
 end
 
 function laplacian2d(nx,ny)
-    n = nx*ny
-    nzest = 5n
-    I = @compat sizehint!(Int32[],nzest)
-    J = @compat sizehint!(Int32[],nzest)
-    V = @compat sizehint!(Float64[],nzest)
-    for x in 1:nx
-        for y in 1:ny
-            s = x + (y-1)*nx
-            appendel(I,J,V,s,s,2)
-            x > 1 && appendel(I,J,V,s,s-1,-1)
-            y > 1 && appendel(I,J,V,s,s-nx,-1)
+    M = speye(nx*ny)
+    for x=1:nx
+        for y=1:ny
+            s = x+(y-1)*nx
+            M[s,s] = 4
+            if x > 1 
+                M[s,s-1] = -1
+            end
+            if x < nx 
+                M[s,s+1] = -1 
+            end
+            if y > 1
+                M[s,s-nx] = -1 
+            end
+            if y < ny 
+                M[s,s+nx] = -1
+            end
         end
     end
-    A = sparse(I,J,V,n,n)
-    A + A'
+    M
 end
 
-const A = laplacian2d(40,40);
+(nx,ny) = (100,100)
+leafSize = 64;
 
-p = [1:size(A,1)]
-const root = Supernode(simple_adjlist(A),p);
+A = laplacian2d(nx,ny)
+
+g = sparseToAdj(A);
+b = randn(nx*ny,1) ;
+p = collect(1:size(A,1))
+
+# Bissect
+root = Supernode(g,p)
+Aperm = A[p,p]
+# Build front
+front = Front{Float64}(Aperm,root)
+# Factorize
+MultiFrontalCholesky.Cholesky!(front)
+
+# Check LDLt front
+# LD = MultiFrontalCholesky.Unpack(front,root)
+# D = diagm(diag(LD))
+# L = tril(LD,-1)+speye(size(D,1),size(D,2))
+# println("Facto quality : ", norm(Aperm-L*D*L',Inf)/norm(A,Inf))
+
+# Solve Ax = b
+sol = MultiFrontalCholesky.Solve(front,root,p,b)
+println("Sol quality : ", norm(A*sol-b)/norm(b)) 
+#sol2 = A\b 
+#println("Done :-)")
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,27 +17,28 @@ function sparseToAdj(M)
     g
 end
 
+function appendel(I,J,V,i,j,v)
+    push!(I,i)
+    push!(J,j)
+    push!(V,v)
+end
+
 function laplacian2d(nx,ny)
-    M = speye(nx*ny)
-    for x=1:nx
-        for y=1:ny
-            s = x+(y-1)*nx
-            M[s,s] = 4
-            if x > 1 
-                M[s,s-1] = -1
-            end
-            if x < nx 
-                M[s,s+1] = -1 
-            end
-            if y > 1
-                M[s,s-nx] = -1 
-            end
-            if y < ny 
-                M[s,s+nx] = -1
-            end
+    n = nx*ny
+    nzest = 5*n
+    I = sizehint!(Int32[],nzest)
+    J = sizehint!(Int32[],nzest)
+    V = sizehint!(Float64[],nzest)
+    for x in 1:nx
+        for y in 1:ny
+            s = x + (y-1)*nx
+            appendel(I,J,V,s,s,2)
+            x > 1 && appendel(I,J,V,s,s-1,-1)
+            y > 1 && appendel(I,J,V,s,s-nx,-1)
         end
     end
-    M
+    A = sparse(I,J,V,n,n)
+    A + A'
 end
 
 (nx,ny) = (100,100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,8 +66,6 @@ MultiFrontalCholesky.Cholesky!(front)
 # Solve Ax = b
 sol = MultiFrontalCholesky.Solve(front,root,p,b)
 println("Sol quality : ", norm(A*sol-b)/norm(b)) 
-#sol2 = A\b 
-#println("Done :-)")
 
 
 


### PR DESCRIPTION
1. I added support for LDLt factorisation. D is stored on the diagonal of L, and since L is unit-lower-triangular, the rest is stored below the diagonal.
   There is no "general syrk" in BLAS so I have my own "pure-julia" implementation. Same for LDLt.
2. I accelerated bissect by building the adjacency list first, and then building the graph object at once
3. I completed the example in runtest, and simplified a bit the laplacian2d code (well, this is actually probably slower, so we can discard this change maybe ?)
   EDIT : re-added the original code for creating the Laplacian. Much faster.
